### PR TITLE
Fix for renewal failing if original certificate had no DNS SANs

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -333,8 +333,8 @@ def enroll(conn, zone, cn=None, private_key=None, public_key=None, password=None
         private_key=private_key,
         key_password=password
     )
+    request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]
     if isinstance(conn, (FakeConnection or TPPConnection)):
-        request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]
         request.email_addresses = ["e1@venafi.example.com", "e2@venafi.example.com"]
         request.ip_addresses = ["127.0.0.1", "192.168.1.1"]
 

--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -282,7 +282,7 @@ class CloudConnection(CommonConnection):
                 request.organizational_unit = c["subjectOU"]
             if c.get("subjectL"):
                 request.locality = c["subjectL"]
-            if c.get("subjectAlternativeNameDns")
+            if c.get("subjectAlternativeNameDns"):
                 request.san_dns = c["subjectAlternativeNameDns"]
             request.key_type = KeyType(KeyType.RSA, c["keyStrength"])
             request.build_csr()

--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -282,8 +282,9 @@ class CloudConnection(CommonConnection):
                 request.organizational_unit = c["subjectOU"]
             if c.get("subjectL"):
                 request.locality = c["subjectL"]
+            if c.get("subjectAlternativeNameDns")
+                request.san_dns = c["subjectAlternativeNameDns"]
             request.key_type = KeyType(KeyType.RSA, c["keyStrength"])
-            request.san_dns = c["subjectAlternativeNameDns"]
             request.build_csr()
             d["certificateSigningRequest"] = request.csr
             d["reuseCSR"] = False


### PR DESCRIPTION
Also updated enrollment tests to include DNS SANs when requesting certificates from Venafi Cloud.