### PR TITLE
Added method venafi_connection to wrap implementations

### DIFF
--- a/examples/get_cert_token.py
+++ b/examples/get_cert_token.py
@@ -17,7 +17,7 @@
 
 from __future__ import print_function
 from vcert import (CertificateRequest, Connection, FakeConnection, TPPConnection, RevocationRequest, KeyType,
-                   token_connection, TPPTokenConnection)
+                   TPPTokenConnection, venafi_connection)
 import string
 import random
 import logging
@@ -43,7 +43,7 @@ def main():
         # If user and password are passed, you can get a new token from them.
         # If access_token and refresh_token are passed, there is no need for the username and password.
         # If only access_token is passed, the Connection will fail when token expires, as there is no way to refresh it.
-        conn = token_connection(url=url, user=user, password=password, http_request_kwargs={"verify": False})
+        conn = venafi_connection(url=url, user=user, password=password, http_request_kwargs={"verify": False})
         # If your TPP server certificate signed with your own CA, or available only via proxy, you can specify
         # a trust bundle using requests vars:
         # conn = token_connection(url=url, user=user, password=password,

--- a/vcert/__init__.py
+++ b/vcert/__init__.py
@@ -49,17 +49,17 @@ def venafi_connection(url=None, api_key=None, user=None, password=None, access_t
                       fake=False, http_request_kwargs=None):
     """
     Return connection based on credentials list.
-    Venafi Platform (TPP) required URL, user, password
-    Cloud required token and optional URL
-    Fake required no parameters
+    Venafi Platform (TPP) requires URL and access_token (or user and password for getting a new access_token)
+    Cloud requires api_key and optional URL
+    Fake requires no parameters
     :param str url: TPP or Venafi Cloud URL (for Cloud is optional)
-    :param str api_key: Venafi Cloud token
-    :param str user: TPP username
-    :param str password: TPP password
+    :param str api_key: Venafi Cloud API Key
+    :param str user: TPP username for getting new tokens
+    :param str password: TPP password for getting new tokens
     :param str access_token: TPP access token
     :param str refresh_token: TPP refresh token (optional)
     :param bool fake: Use fake connection
-    :param dict[str, Any] http_request_kwargs: Option for work with untrusted  https certificate (only for TPP).
+    :param dict[str, Any] http_request_kwargs: Option for specifying trust bundle or to operate insecurely.
     :rtype CommonConnection:
     """
     if fake:

--- a/vcert/__init__.py
+++ b/vcert/__init__.py
@@ -45,6 +45,29 @@ def Connection(url=None, token=None, user=None, password=None, fake=False, http_
         raise Exception("Bad credentials list")
 
 
-def token_connection(url=None, user=None, password=None, access_token=None, refresh_token=None, http_request_kwargs=None):
-    return TPPTokenConnection(url=url, user=user, password=password, access_token=access_token,
-                              refresh_token=refresh_token, http_request_kwargs=http_request_kwargs)
+def venafi_connection(url=None, api_key=None, user=None, password=None, access_token=None, refresh_token=None,
+                      fake=False, http_request_kwargs=None):
+    """
+    Return connection based on credentials list.
+    Venafi Platform (TPP) required URL, user, password
+    Cloud required token and optional URL
+    Fake required no parameters
+    :param str url: TPP or Venafi Cloud URL (for Cloud is optional)
+    :param str api_key: Venafi Cloud token
+    :param str user: TPP username
+    :param str password: TPP password
+    :param str access_token: TPP access token
+    :param str refresh_token: TPP refresh token (optional)
+    :param bool fake: Use fake connection
+    :param dict[str, Any] http_request_kwargs: Option for work with untrusted  https certificate (only for TPP).
+    :rtype CommonConnection:
+    """
+    if fake:
+        return FakeConnection()
+    if url and (access_token or (user and password)):
+        return TPPTokenConnection(url=url, user=user, password=password, access_token=access_token,
+                                  refresh_token=refresh_token, http_request_kwargs=http_request_kwargs)
+    if api_key:
+        return CloudConnection(token=api_key, url=url, http_request_kwargs=http_request_kwargs)
+    else:
+        raise Exception("Bad credentials list")

--- a/vcert/connection_tpp_token.py
+++ b/vcert/connection_tpp_token.py
@@ -381,6 +381,9 @@ class TPPTokenConnection(CommonConnection):
         if authentication and isinstance(authentication, Authentication):
             self._auth = authentication
 
+        if self._auth.user is None or self._auth.password is None:
+            raise ClientBadData("user/password missing. Cannot request new access token")
+
         request_data = {
             "username": self._auth.user,
             "password": self._auth.password,


### PR DESCRIPTION
…d and TPP Token.

TPP user and password is not supported in this method. However user and password can still be passed to the method as arguments to get an initial access token.

Updated the TPP Token example
Added a validation for connection_tpp_token.get_access_token() for the scenario where there is no user/password.