### PR TITLE
Pm fixes

### DIFF
--- a/examples/set_policy_tpp_token.py
+++ b/examples/set_policy_tpp_token.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 Venafi, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pprint import pprint
+
+from parser import json_parser, yaml_parser
+from parser.utils import parse_policy_spec
+from policy.policy_spec import PolicySpecification, Policy, Subject, KeyPair, SubjectAltNames, Defaults, \
+    DefaultSubject, DefaultKeyPair
+from vcert import venafi_connection
+from vcert.common import Authentication, SCOPE_PM
+import logging
+from os import environ
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+
+
+def main():
+    # Get credentials from environment variables
+    url = environ.get('TPP_TOKEN_URL')
+    user = environ.get('TPP_USER')
+    password = environ.get('TPP_PASSWORD')
+    zone = environ.get('TPP_ZONE')
+    server_trust_bundle = environ.get('TPP_TRUST_BUNDLE')
+
+    # Get connector object.
+    # The default state of this connection only allows for certificate management.
+    connector = venafi_connection(url=url, user=user, password=password,
+                                  http_request_kwargs={"verify": server_trust_bundle})
+
+    # Create Authentication object with required scope for policy management.
+    auth = Authentication(user=user, password=password, scope=SCOPE_PM)
+    # Additionally, change the client id for a custom one.
+    # Make sure this id has been registered on the TPP instance beforehand.
+    auth.client_id = 'vcert-tpp-demo'
+
+    # Request access token with values specified in auth object.
+    # After the request is successful, subsequent api calls will use the same token.
+    connector.get_access_token(auth)
+
+    # Define policy specification object to create a new policy
+    ps = PolicySpecification()
+    # Alternatively, the parser utilities can be used to read a json/yaml file into a PolicySpecification object
+    # ps = json_parser.parse_file('path/to/file.json')
+    # ps = yaml_parser.parse_file('path/to/file.yaml')
+
+    # All of the following values can be omitted to create a Policy with inherited (TPP) or recommended (Cloud) settings
+    ps.policy = Policy(
+        subject=Subject(
+            orgs=['OSS Venafi, Inc.'],
+            org_units=['Customer Support', 'Professional Services'],
+            localities=['Salt Lake City'],
+            states=['Utah'],
+            countries=['US']
+        ),
+        key_pair=KeyPair(
+            key_types=['RSA'],
+            rsa_key_sizes=[4096],
+            elliptic_curves=['P521'],
+            reuse_allowed=True
+        ),
+        subject_alt_names=SubjectAltNames(
+            dns_allowed=True,
+            ip_allowed=False,
+            email_allowed=False,
+            uri_allowed=False,
+            upn_allowed=False
+        ),
+        cert_auth=None,
+        domains=['vfidev.com', 'vfidev.net', 'venafi.example'],
+        wildcard_allowed=True,
+        auto_installed=False
+    )
+    ps.defaults = Defaults(
+        d_subject=DefaultSubject(
+            org='OSS Venafi, Inc.',
+            org_units=['Customer Support', 'Professional Services'],
+            locality='Salt Lake City',
+            state='Utah',
+            country='US'
+        ),
+        d_key_pair=DefaultKeyPair(
+            key_type='RSA',
+            rsa_key_size=4096,
+            elliptic_curve='P521'
+        ),
+        auto_installed=False
+    )
+
+    # Create the new policy in the path specified by zone
+    # If the policy already exists, it will be updated instead with the new settings
+    connector.set_policy(zone, ps)
+
+    # Retrieve the Policy from the Venafi Platform
+    response = connector.get_policy(zone)
+
+    # Transform the PolicySpecification object to a serializable form
+    data = parse_policy_spec(response)
+    # Print the transformed data
+    pprint(data)
+    # Alternatively the parser utilities can be used to serialize the PolicySpecification object to a json/yaml file
+    # json_parser.serialize(response, 'path/to/file.json')
+    # yaml_parser.serialize(response, 'path/to/file.yaml')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/set_policy_vaas.py
+++ b/examples/set_policy_vaas.py
@@ -18,8 +18,8 @@ from pprint import pprint
 
 from parser import json_parser, yaml_parser
 from parser.utils import parse_policy_spec
-from policy.policy_spec import PolicySpecification, Policy, Subject, KeyPair, SubjectAltNames, Defaults, DefaultSubject, \
-    DefaultKeyPair
+from policy.policy_spec import PolicySpecification, Policy, Subject, KeyPair, SubjectAltNames, Defaults, \
+    DefaultSubject, DefaultKeyPair
 from vcert import venafi_connection
 import logging
 from os import environ
@@ -30,11 +30,11 @@ logging.getLogger("urllib3").setLevel(logging.ERROR)
 
 def main():
     # Get credentials from environment variables
-    zone = environ.get('CLOUD_ZONE')
-    api_key = environ.get('CLOUD_APIKEY')
+    zone = environ.get('VAAS_ZONE')
+    api_key = environ.get('VAAS_APIKEY')
 
     # Get connector object
-    conn = venafi_connection(api_key=api_key)
+    connector = venafi_connection(api_key=api_key)
 
     # Define policy specification object to create a new policy
     ps = PolicySpecification()
@@ -87,10 +87,10 @@ def main():
 
     # Create the new policy in the path specified by zone
     # If the policy already exists, it will be updated instead with the new settings
-    conn.set_policy(zone, ps)
+    connector.set_policy(zone, ps)
 
     # Retrieve the Policy from the Venafi Platform
-    response = conn.get_policy(zone)
+    response = connector.get_policy(zone)
 
     # Transform the PolicySpecification object to a serializable form
     data = parse_policy_spec(response)
@@ -99,3 +99,7 @@ def main():
     # Alternatively the parser utilities can be used to serialize the PolicySpecification object to a json/yaml file
     # json_parser.serialize(response, 'path/to/file.json')
     # yaml_parser.serialize(response, 'path/to/file.yaml')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -139,9 +139,14 @@ class TestCloudPolicyManagement(unittest.TestCase):
     def test_create_policy_digicert(self):
         self._create_policy_cloud(policy=_get_policy_obj(ca_type=CA_TYPE_DIGICERT), defaults=_get_defaults_obj())
 
+    def test_validate_domains(self):
+        policy = self._create_policy_cloud(policy=_get_policy_obj())
+        self.assertListEqual(policy.policy.domains, POlICY_DOMAINS)
+
     def _create_policy_cloud(self, policy_spec=None, policy=None, defaults=None):
         zone = self._get_random_zone()
-        create_policy(self.cloud_conn, zone, policy_spec, policy, defaults)
+        response = create_policy(self.cloud_conn, zone, policy_spec, policy, defaults)
+        return response
 
     @staticmethod
     def _get_random_zone():
@@ -164,6 +169,9 @@ def create_policy(connector, zone, policy_spec=None, policy=None, defaults=None)
     return resp
 
 
+POlICY_DOMAINS = ['vfidev.com', 'vfidev.net', 'venafi.example']
+
+
 def _get_policy_obj(ca_type=None):
     policy = Policy(
         subject=Subject(
@@ -183,7 +191,7 @@ def _get_policy_obj(ca_type=None):
             email_allowed=False,
             uri_allowed=False,
             upn_allowed=False),
-        domains=['vfidev.com', 'vfidev.net', 'venafi.example'],
+        domains=POlICY_DOMAINS,
         wildcard_allowed=True,
         auto_installed=False)
 

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -147,7 +147,7 @@ class TestCloudPolicyManagement(unittest.TestCase):
 
     def test_validate_domains(self):
         policy = self._create_policy_cloud(policy=_get_policy_obj())
-        self.assertListEqual(policy.policy.domains, POlICY_DOMAINS)
+        self.assertListEqual(policy.policy.domains, POLICY_DOMAINS)
 
     def _create_policy_cloud(self, policy_spec=None, policy=None, defaults=None):
         zone = self._get_random_zone()
@@ -175,7 +175,7 @@ def create_policy(connector, zone, policy_spec=None, policy=None, defaults=None)
     return resp
 
 
-POlICY_DOMAINS = ['vfidev.com', 'vfidev.net', 'venafi.example']
+POLICY_DOMAINS = ['vfidev.com', 'vfidev.net', 'venafi.example']
 
 
 def _get_policy_obj(ca_type=None):
@@ -197,7 +197,7 @@ def _get_policy_obj(ca_type=None):
             email_allowed=False,
             uri_allowed=False,
             upn_allowed=False),
-        domains=POlICY_DOMAINS,
+        domains=POLICY_DOMAINS,
         wildcard_allowed=True,
         auto_installed=False)
 

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -25,6 +25,7 @@ from future.backports.datetime import datetime
 from test_env import TPP_TOKEN_URL, CLOUD_APIKEY, CLOUD_URL, TPP_PM_ROOT, CLOUD_ENTRUST_CA_NAME, \
     CLOUD_DIGICERT_CA_NAME, TPP_CA_NAME, TPP_USER, TPP_PASSWORD
 from vcert import TPPTokenConnection, CloudConnection
+from vcert.common import Authentication, SCOPE_PM
 from vcert.parser import json_parser, yaml_parser
 from vcert.parser.utils import parse_policy_spec
 from vcert.policy import Policy, Subject, KeyPair, SubjectAltNames, Defaults, DefaultSubject, DefaultKeyPair, \
@@ -71,8 +72,9 @@ class TestParsers(unittest.TestCase):
 
 class TestTPPPolicyManagement(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        self.tpp_conn = TPPTokenConnection(url=TPP_TOKEN_URL, user=TPP_USER, password=TPP_PASSWORD,
-                                           http_request_kwargs={"verify": "/tmp/chain.pem"})
+        self.tpp_conn = TPPTokenConnection(url=TPP_TOKEN_URL, http_request_kwargs={"verify": "/tmp/chain.pem"})
+        auth = Authentication(user=TPP_USER, password=TPP_PASSWORD, scope=SCOPE_PM)
+        self.tpp_conn.get_access_token(auth)
         self.json_file = _resolve_resources_path(POLICY_SPEC_JSON)
         self.yaml_file = _resolve_resources_path(POLICY_SPEC_YAML)
         super(TestTPPPolicyManagement, self).__init__(*args, **kwargs)
@@ -250,7 +252,8 @@ def _get_zone():
 
 
 def _get_tpp_policy_name():
-    return _get_app_name()
+    timestamp = _get_timestamp()
+    return _get_app_name() % timestamp
 
 
 def _resolve_resources_path(path):

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -88,7 +88,9 @@ class TestTPPPolicyManagement(unittest.TestCase):
         pass
 
     def test_create_policy_full(self):
-        self._create_policy_tpp(policy=_get_policy_obj(ca_type=CA_TYPE_TPP), defaults=_get_defaults_obj())
+        policy = _get_policy_obj(ca_type=CA_TYPE_TPP)
+        policy.key_pair.rsa_key_sizes = [2048]
+        self._create_policy_tpp(policy=policy, defaults=_get_defaults_obj())
 
     def test_create_policy_empty(self):
         self._create_policy_tpp()
@@ -97,7 +99,9 @@ class TestTPPPolicyManagement(unittest.TestCase):
         self._create_policy_tpp(defaults=_get_defaults_obj())
 
     def test_create_policy_no_defaults(self):
-        self._create_policy_tpp(policy=_get_policy_obj(ca_type=CA_TYPE_TPP))
+        policy = _get_policy_obj(ca_type=CA_TYPE_TPP)
+        policy.key_pair.rsa_key_sizes = [2048]
+        self._create_policy_tpp(policy=policy)
 
     def _create_policy_tpp(self, policy_spec=None, policy=None, defaults=None):
         zone = '%s\\%s' % (TPP_PM_ROOT, _get_tpp_policy_name())

--- a/vcert/common.py
+++ b/vcert/common.py
@@ -559,9 +559,9 @@ CLIENT_ID = "vcert-sdk"  # type: str
 # Certificate Management scope
 SCOPE_CM = "certificate:manage,revoke"  # type: str
 # Policy Management scope
-SCOPE_PM = 'configuration:manage'  # type: str
+SCOPE_PM = 'certificate:manage;configuration:manage'  # type: str
 # Full Management scope
-SCOPE_FULL = '%s;%s' % (SCOPE_PM, SCOPE_PM)
+SCOPE_FULL = 'certificate:manage,revoke;configuration:manage'  # type: str
 
 
 class Authentication:

--- a/vcert/common.py
+++ b/vcert/common.py
@@ -559,9 +559,9 @@ CLIENT_ID = "vcert-sdk"  # type: str
 # Certificate Management scope
 SCOPE_CM = "certificate:manage,revoke"  # type: str
 # Policy Management scope
-SCOPE_PM = 'certificate:manage;configuration:manage'  # type: str
+SCOPE_PM = "certificate:manage;configuration:manage"  # type: str
 # Full Management scope
-SCOPE_FULL = 'certificate:manage,revoke;configuration:manage'  # type: str
+SCOPE_FULL = "certificate:manage,revoke;configuration:manage"  # type: str
 
 
 class Authentication:

--- a/vcert/common.py
+++ b/vcert/common.py
@@ -556,12 +556,17 @@ class RevocationRequest:
 
 
 CLIENT_ID = "vcert-sdk"  # type: str
-SCOPE = "certificate:manage,revoke;configuration:manage"  # type: str
+# Certificate Management scope
+SCOPE_CM = "certificate:manage,revoke"  # type: str
+# Policy Management scope
+SCOPE_PM = 'configuration:manage'  # type: str
+# Full Management scope
+SCOPE_FULL = '%s;%s' % (SCOPE_PM, SCOPE_PM)
 
 
 class Authentication:
     def __init__(self, user=None, password=None, access_token=None, refresh_token=None, api_key=None, state=None,
-                 token_expires=None, client_id=CLIENT_ID, scope=SCOPE):
+                 token_expires=None, client_id=CLIENT_ID, scope=SCOPE_CM):
         self.user = user
         self.password = password
         self.access_token = access_token


### PR DESCRIPTION
Fixes #54 and #55 

Fixed an issue related with domain names in VaaS platform. A regex is added to them when creating a policy, but are not removed when reading that same policy. This issue effectively rendered the policy template unusable for future policy creation actions.

Fixed an issue on TPP policy management test suite. The random policy name was being generated incorrectly and made tests fail.

Fixed an issue on VaaS policy management logic. The Country regexes were being passed as the common name regexes due to an error in variable naming.