### PR TITLE
Added a default timeout for request operations in both TPP and VaaS

### DIFF
--- a/vcert/common.py
+++ b/vcert/common.py
@@ -44,6 +44,7 @@ MIME_TEXT = "text/plain"
 MIME_CSV = "text/csv"
 MIME_ANY = "*/*"
 LOCALHOST = "127.0.0.1"
+DEFAULT_TIMEOUT = 180
 
 
 class CertField:
@@ -255,7 +256,7 @@ class CertificateRequest:
                  locality=None,
                  origin=None,
                  custom_fields=None,
-                 timeout=0
+                 timeout=DEFAULT_TIMEOUT
                  ):
         """
         :param str cert_id: Certificate request id. Generating by server.

--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -26,7 +26,7 @@ import requests
 import six.moves.urllib.parse as urlparse
 
 from .common import (ZoneConfig, CertificateRequest, CommonConnection, Policy, get_ip_address, log_errors, MIME_JSON,
-                     MIME_TEXT, MIME_ANY, CertField, KeyType, AppDetails, RecommendedSettings)
+                     MIME_TEXT, MIME_ANY, CertField, KeyType, AppDetails, RecommendedSettings, DEFAULT_TIMEOUT)
 from .errors import (VenafiConnectionError, ServerUnexptedBehavior, ClientBadData, CertificateRequestError,
                      CertificateRenewError, VenafiError, RetrieveCertificateTimeoutError)
 from .http import HTTPStatus
@@ -444,7 +444,7 @@ class CloudConnection(CommonConnection):
             log.error("server unexpected status %s" % status)
             raise CertificateRenewError
 
-    def search_by_thumbprint(self, thumbprint, timeout=0):
+    def search_by_thumbprint(self, thumbprint, timeout=DEFAULT_TIMEOUT):
         """
         :param str thumbprint:
         :param int timeout:


### PR DESCRIPTION
Removed fixed timeouts from testing suite to let it use the default value.