### PR TITLE
Fixes for policy management request

### DIFF
--- a/examples/ssh_certificates/get_cert_ssh.py
+++ b/examples/ssh_certificates/get_cert_ssh.py
@@ -69,7 +69,7 @@ def main():
         "permit-pty": ""
     }
     # Include the locally-generated public key. If not set, the server will generate one for the certificate
-    request.public_key_data = ssh_kp.public_key()
+    request.set_public_key_data(ssh_kp.public_key())
 
     # Request the certificate from TPP instance
     success = connector.request_ssh_cert(request)

--- a/vcert/connection_tpp_abstract.py
+++ b/vcert/connection_tpp_abstract.py
@@ -318,6 +318,11 @@ class AbstractTPPConnection(CommonConnection):
                 response_object = SSHResponse(data["Response"])
                 if response_object.success:
                     return SSHRetrieveResponse(data)
+                else:
+                    log.info("Failed to retrieve certificate with following details:\n"
+                             "DN: %s\nGuid: %s\nErrorCode: %s\nErrorMessage:%s"
+                             % (json_request['DN'], json_request['Guid'], response_object.error_code,
+                                response_object.error_msg))
 
             if (time.time() - time_start) < request.timeout:
                 log.debug("Waiting for certificate...")

--- a/vcert/connection_tpp_token.py
+++ b/vcert/connection_tpp_token.py
@@ -119,7 +119,7 @@ class TPPTokenConnection(AbstractTPPConnection):
             u = "https://" + u
         if not u.endswith("/"):
             u += "/"
-        if not re.match(r"^https://[a-z\d]+[-a-z\d.]+[a-z\d][:\d]*/$", u):
+        if not re.match(r"^https://[a-zA-Z\d]+[-a-zA-Z\d.]+[a-zA-Z\d][:\d]*/$", u):
             raise ClientBadData
         return u
 

--- a/vcert/policy/pm_cloud.py
+++ b/vcert/policy/pm_cloud.py
@@ -432,7 +432,6 @@ def build_cit_request(ps, ca_details):
         r_settings['key'] = r_key
 
     if r_settings:
-        r_settings['keyReuse'] = False
         request['recommendedSettings'] = r_settings
 
     return request


### PR DESCRIPTION
- Fixed an issue with the url validation regex, which not allowed for upper case characters.
- Added Log info to retrieve_ssh_cert() method
- Fixed get_cert_ssh.py example. Calls to the public key data has been updated.
- Removed 'keyReuse' from the policy creation json request, as it is no longer supported by VaaS.