### PR TITLE
Adding support for PKCS1 format on private keys

### DIFF
--- a/tests/test_tpp.py
+++ b/tests/test_tpp.py
@@ -139,7 +139,7 @@ class TestTPPMethods(unittest.TestCase):
         with self.assertRaises(Exception):
             self.tpp_conn.retrieve_cert(self.tpp_zone + "\\devops\\vcert\\test-non-issued.example.com")
 
-    def test_tpp_search_by_thumbpint(self):
+    def test_tpp_search_by_thumbprint(self):
         req, cert = simple_enroll(self.tpp_conn, self.tpp_zone)
         cert = x509.load_pem_x509_certificate(cert.cert.encode(), default_backend())
         fingerprint = binascii.hexlify(cert.fingerprint(hashes.SHA1())).decode()

--- a/tests/test_vaas.py
+++ b/tests/test_vaas.py
@@ -35,11 +35,11 @@ from vcert.policy import KeyPair, DefaultKeyPair, PolicySpecification
 log = logger.get_child("test-vaas")
 
 
-class TestCloudMethods(unittest.TestCase):
+class TestVaaSMethods(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         self.cloud_zone = CLOUD_ZONE
         self.cloud_conn = CloudConnection(token=CLOUD_APIKEY, url=CLOUD_URL)
-        super(TestCloudMethods, self).__init__(*args, **kwargs)
+        super(TestVaaSMethods, self).__init__(*args, **kwargs)
 
     def test_cloud_enroll(self):
         cn = f"{random_word(10)}.venafi.example.com"

--- a/vcert/common.py
+++ b/vcert/common.py
@@ -276,7 +276,8 @@ class CertificateRequest:
                  csr_origin=CSR_ORIGIN_LOCAL,
                  include_private_key=False,
                  validity_hours=None,
-                 issuer_hint=IssuerHint.DEFAULT):
+                 issuer_hint=IssuerHint.DEFAULT,
+                 use_legacy_pem=False):
         """
         :param str cert_id: Certificate request id. Generating by server.
         :param list[str] san_dns: Alternative names for SNI.
@@ -304,6 +305,7 @@ class CertificateRequest:
         :param bool include_private_key: Indicates if the private key should be returned by the server or not.
         :param int validity_hours: time in hours before the certificate expires.
         :param IssuerHint issuer_hint: Issuer of the certificate. Ignored when platform is not TPP.
+        :param bool use_legacy_pem: Flag that indicates the private key must be in PKCS1 format. Default is PKCS8.
         """
 
         self.chain_option = CHAIN_OPTION_LAST  # "last"
@@ -340,6 +342,7 @@ class CertificateRequest:
         self.include_private_key = include_private_key
         self.validity_hours = validity_hours
         self.issuer_hint = issuer_hint
+        self.use_legacy_pem = use_legacy_pem
 
     def __setattr__(self, key, value):
         if key == "key_password":
@@ -501,9 +504,14 @@ class CertificateRequest:
         else:
             encryption = serialization.NoEncryption()
 
+        if self.use_legacy_pem:
+            pk_format = serialization.PrivateFormat.TraditionalOpenSSL
+        else:
+            pk_format = serialization.PrivateFormat.PKCS8
+
         return self.private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            format=pk_format,
             encryption_algorithm=encryption,
         ).decode()
 

--- a/vcert/connection_tpp_abstract.py
+++ b/vcert/connection_tpp_abstract.py
@@ -182,8 +182,11 @@ class AbstractTPPConnection(CommonConnection):
         log.debug(f"Getting certificate status for id {cert_request.id}")
 
         retrieve_request = dict(CertificateDN=cert_request.id,
-                                Format="base64",
+                                Format="Base64 (PKCS #8)",
                                 IncludeChain=True)
+
+        if cert_request.use_legacy_pem:
+            retrieve_request["Format"] = "base64"
 
         if cert_request.csr_origin == CSR_ORIGIN_SERVICE:
             retrieve_request['IncludePrivateKey'] = cert_request.include_private_key


### PR DESCRIPTION
VaaS and TPP now default private key formats to PKCS8, a flag has been introduced allowing users to indicate they want the private key on the legacy PKCS1 format