### PR TITLE
Adding ability to disable subject fields for VaaS

### DIFF
--- a/tests/resources/policy_specification.json
+++ b/tests/resources/policy_specification.json
@@ -73,7 +73,7 @@
       "keyType": "RSA",
       "rsaKeySize": 2048,
       "ellipticCurve": "",
-      "serviceGenerated": false
+      "serviceGenerated": true
     }
   }
 }

--- a/tests/resources/policy_specification.json
+++ b/tests/resources/policy_specification.json
@@ -2,7 +2,9 @@
   "policy": {
     "domains": [
       "venafi.com",
-      "kwan.com"
+      "vfidev.com",
+      "vfidev.net",
+      "venafi.example"
     ],
     "wildcardAllowed": true,
     "maxValidDays": 120,
@@ -25,23 +27,35 @@
     },
     "keyPair": {
       "keyTypes": [
-        "RSA"
+        "RSA",
+        "EC"
       ],
       "rsaKeySizes": [
-        2048
+        2048,
+        4096
       ],
       "ellipticCurves": [
+        "P521",
         "P384"
       ],
-      "serviceGenerated": false,
+      "serviceGenerated": true,
       "reuseAllowed": false
     },
     "subjectAltNames": {
-      "dnsAllowed": false,
-      "ipAllowed": false,
-      "emailAllowed": false,
-      "uriAllowed": false,
-      "upnAllowed": false
+      "dnsAllowed": true,
+      "ipAllowed": true,
+      "emailAllowed": true,
+      "uriAllowed": true,
+      "upnAllowed": false,
+      "ipConstraints": [
+        "v4",
+        "v6"
+      ],
+      "uriProtocols": [
+        "https",
+        "ldaps",
+        "spiffe"
+      ]
     }
   },
   "defaults": {

--- a/tests/resources/policy_specification.yaml
+++ b/tests/resources/policy_specification.yaml
@@ -2,8 +2,9 @@
 policy:
   domains:
     - venafi.com
-    - kwan.com
-    - yaml.com
+    - vfidev.com
+    - vfidev.net
+    - venafi.example
   wildcardAllowed: true
   maxValidDays: 120
   subject:
@@ -16,22 +17,32 @@ policy:
     states:
       - Yucatan
     countries:
-      - US
+      - MX
   keyPair:
     keyTypes:
       - RSA
+      - EC
     rsaKeySizes:
       - 2048
+      - 4096
     ellipticCurves:
+      - P521
       - P384
-    serviceGenerated: false
+    serviceGenerated: true
     reuseAllowed: false
   subjectAltNames:
-    dnsAllowed: false
-    ipAllowed: false
-    emailAllowed: false
-    uriAllowed: false
+    dnsAllowed: true
+    ipAllowed: true
+    emailAllowed: true
+    uriAllowed: true
     upnAllowed: false
+    ipConstraints:
+      - v4
+      - v6
+    uriProtocols:
+      - https
+      - ldaps
+      - spiffe
 defaults:
   domain: venafi.com
   subject:
@@ -40,9 +51,9 @@ defaults:
       - DevOps
     locality: Merida
     state: Yucatan
-    country: Mexico
+    country: MX
   keyPair:
     keyType: RSA
     rsaKeySize: 2048
     ellipticCurve: ''
-    serviceGenerated: ''
+    serviceGenerated: true

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -153,12 +153,12 @@ class TestTPPPolicyManagement(unittest.TestCase):
         create_policy(self.tpp_conn, zone, policy_spec, policy, defaults)
 
 
-class TestCloudPolicyManagement(unittest.TestCase):
+class TestVaaSPolicyManagement(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         self.cloud_conn = CloudConnection(token=CLOUD_APIKEY, url=CLOUD_URL)
         self.json_file = POLICY_SPEC_JSON
         self.yaml_file = POLICY_SPEC_YAML
-        super(TestCloudPolicyManagement, self).__init__(*args, **kwargs)
+        super(TestVaaSPolicyManagement, self).__init__(*args, **kwargs)
 
     def test_create_policy_from_json(self):
         # ps = json_parser.parse_file(self.json_file)
@@ -328,6 +328,23 @@ class TestCloudPolicyManagement(unittest.TestCase):
         result = connector.get_policy(zone)
         self.assertEqual(1, len(result.users))
         self.assertEqual(CLOUD_TEAM, result.users[0])
+
+    def test_create_policy_disabled_subject_fields(self):
+        zone = get_vaas_zone()
+        policy = get_policy_obj()
+        policy.subject.orgs = [""]
+        policy.subject.org_units = [""]
+        policy.subject.localities = [""]
+        policy.subject.states = [""]
+        policy.subject.countries = [""]
+        ps_response = create_policy(connector=self.cloud_conn, zone=zone,policy=policy)
+        self.assertIsNotNone(ps_response.policy)
+        self.assertIsNotNone(ps_response.policy.subject)
+        self.assertListEqual(ps_response.policy.subject.orgs, [""])
+        self.assertListEqual(ps_response.policy.subject.org_units, [""])
+        self.assertListEqual(ps_response.policy.subject.localities, [""])
+        self.assertListEqual(ps_response.policy.subject.states, [""])
+        self.assertListEqual(ps_response.policy.subject.countries, [""])
 
     def _create_policy_cloud(self, policy_spec=None, policy=None, defaults=None):
         zone = get_vaas_zone()

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -72,17 +72,29 @@ class TestParsers(unittest.TestCase):
         """
         self.assertIsNotNone(ps)
         self.assertIn("venafi.com", ps.policy.domains)
-        self.assertIn("kwan.com", ps.policy.domains)
+        self.assertIn("vfidev.com", ps.policy.domains)
+        self.assertIn("vfidev.net", ps.policy.domains)
+        self.assertIn("venafi.example", ps.policy.domains)
         self.assertIn("venafi.com", ps.policy.subject.orgs)
         self.assertTrue(len(ps.policy.subject.orgs) == 1)
         self.assertIn("DevOps", ps.policy.subject.org_units)
         self.assertTrue(len(ps.policy.subject.org_units) == 1)
         self.assertIn("Merida", ps.policy.subject.localities)
         self.assertTrue(len(ps.policy.subject.localities) == 1)
+
+        self.assertIn("Yucatan", ps.policy.subject.states)
+        self.assertTrue(len(ps.policy.subject.states) == 1)
+
+        self.assertIn("MX", ps.policy.subject.countries)
+        self.assertTrue(len(ps.policy.subject.countries) == 1)
+
         self.assertIn("RSA", ps.policy.key_pair.key_types)
-        self.assertTrue(len(ps.policy.key_pair.key_types) == 1)
+        self.assertIn("EC", ps.policy.key_pair.key_types)
+        self.assertTrue(len(ps.policy.key_pair.key_types) == 2)
         self.assertIn(2048, ps.policy.key_pair.rsa_key_sizes)
-        self.assertTrue(len(ps.policy.key_pair.rsa_key_sizes) == 1)
+        self.assertIn(4096, ps.policy.key_pair.rsa_key_sizes)
+        self.assertIn("P521", ps.policy.key_pair.elliptic_curves)
+        self.assertIn("P384", ps.policy.key_pair.elliptic_curves)
 
 
 class TestTPPPolicyManagement(unittest.TestCase):

--- a/vcert/policy/pm_cloud.py
+++ b/vcert/policy/pm_cloud.py
@@ -88,30 +88,6 @@ def build_policy_spec(cit, ca_info, subject_cn_to_str=True):
         ca = f"{ca_info.ca_type}\\{ca_info.ca_account_key}\\{ca_info.vendor_name}"
         p.certificate_authority = ca
 
-    # s = Subject()
-    # create_subject = False
-    # if cit.SubjectORegexes is None:
-    #     s.orgs = [""]
-    # elif len(cit.SubjectORegexes) > 0:
-    #     create_subject = True
-    #     s.orgs = cit.SubjectORegexes
-    #
-    # if len(cit.SubjectOURegexes) > 0:
-    #     create_subject = True
-    #     s.org_units = cit.SubjectOURegexes
-    #
-    # if len(cit.SubjectLRegexes) > 0:
-    #     create_subject = True
-    #     s.localities = cit.SubjectLRegexes
-    #
-    # if len(cit.SubjectSTRegexes) > 0:
-    #     create_subject = True
-    #     s.states = cit.SubjectSTRegexes
-    #
-    # if len(cit.SubjectCRegexes) > 0:
-    #     create_subject = True
-    #     s.countries = cit.SubjectCRegexes
-
     p.subject = build_policy_spec_subject(cit)
 
     kp = KeyPair()

--- a/vcert/policy/pm_cloud.py
+++ b/vcert/policy/pm_cloud.py
@@ -88,25 +88,31 @@ def build_policy_spec(cit, ca_info, subject_cn_to_str=True):
         ca = f"{ca_info.ca_type}\\{ca_info.ca_account_key}\\{ca_info.vendor_name}"
         p.certificate_authority = ca
 
-    s = Subject()
-    create_subject = False
-    if len(cit.SubjectORegexes) > 0:
-        create_subject = True
-        s.orgs = cit.SubjectORegexes
-    if len(cit.SubjectOURegexes) > 0:
-        create_subject = True
-        s.org_units = cit.SubjectOURegexes
-    if len(cit.SubjectLRegexes) > 0:
-        create_subject = True
-        s.localities = cit.SubjectLRegexes
-    if len(cit.SubjectSTRegexes) > 0:
-        create_subject = True
-        s.states = cit.SubjectSTRegexes
-    if len(cit.SubjectCRegexes) > 0:
-        create_subject = True
-        s.countries = cit.SubjectCRegexes
+    # s = Subject()
+    # create_subject = False
+    # if cit.SubjectORegexes is None:
+    #     s.orgs = [""]
+    # elif len(cit.SubjectORegexes) > 0:
+    #     create_subject = True
+    #     s.orgs = cit.SubjectORegexes
+    #
+    # if len(cit.SubjectOURegexes) > 0:
+    #     create_subject = True
+    #     s.org_units = cit.SubjectOURegexes
+    #
+    # if len(cit.SubjectLRegexes) > 0:
+    #     create_subject = True
+    #     s.localities = cit.SubjectLRegexes
+    #
+    # if len(cit.SubjectSTRegexes) > 0:
+    #     create_subject = True
+    #     s.states = cit.SubjectSTRegexes
+    #
+    # if len(cit.SubjectCRegexes) > 0:
+    #     create_subject = True
+    #     s.countries = cit.SubjectCRegexes
 
-    p.subject = s if create_subject else None
+    p.subject = build_policy_spec_subject(cit)
 
     kp = KeyPair()
     create_kp = False
@@ -202,6 +208,63 @@ def build_policy_spec(cit, ca_info, subject_cn_to_str=True):
 
         ps.defaults = d
     return ps
+
+
+def build_policy_spec_subject(cit):
+    """
+
+    :param Cit cit:
+    :return:
+    """
+    s = Subject()
+    return_subject = False
+
+    orgs_values = None
+    if cit.SubjectORegexes is None:
+        orgs_values = [""]
+    elif len(cit.SubjectORegexes) > 0:
+        orgs_values = cit.SubjectORegexes
+    if orgs_values:
+        s.orgs = orgs_values
+        return_subject = True
+
+    org_units_values = None
+    if cit.SubjectOURegexes is None:
+        org_units_values = [""]
+    elif len(cit.SubjectOURegexes) > 0:
+        org_units_values = cit.SubjectOURegexes
+    if org_units_values:
+        s.org_units = org_units_values
+        return_subject = True
+
+    localities_values = None
+    if cit.SubjectLRegexes is None:
+        localities_values = [""]
+    elif len(cit.SubjectLRegexes) > 0:
+        localities_values = cit.SubjectLRegexes
+    if localities_values:
+        s.localities = localities_values
+        return_subject = True
+
+    states_values = None
+    if cit.SubjectSTRegexes is None:
+        states_values = [""]
+    elif len(cit.SubjectSTRegexes) > 0:
+        states_values = cit.SubjectSTRegexes
+    if states_values:
+        s.states = states_values
+        return_subject = True
+
+    countries_values = None
+    if cit.SubjectCRegexes is None:
+        countries_values = [""]
+    elif len(cit.SubjectCRegexes) > 0:
+        countries_values = cit.SubjectCRegexes
+    if countries_values:
+        s.countries = countries_values
+        return_subject = True
+
+    return s if return_subject else None
 
 
 def validate_policy_spec(policy_spec):
@@ -505,27 +568,42 @@ def build_cit_request(ps, ca_details):
             request['sanIpAddressRegexes'] = [re_ipv4, re_ipv6]
 
     if ps.policy and ps.policy.subject and len(ps.policy.subject.orgs) > 0:
-        request['subjectORegexes'] = ps.policy.subject.orgs
+        if len(ps.policy.subject.orgs) == 1 and ps.policy.subject.orgs[0] == "":
+            request['subjectORegexes'] = None
+        else:
+            request['subjectORegexes'] = ps.policy.subject.orgs
     else:
         request['subjectORegexes'] = [re_allow_all]
 
     if ps.policy and ps.policy.subject and len(ps.policy.subject.org_units) > 0:
-        request['subjectOURegexes'] = ps.policy.subject.org_units
+        if len(ps.policy.subject.org_units) == 1 and ps.policy.subject.org_units[0] == "":
+            request['subjectOURegexes'] = None
+        else:
+            request['subjectOURegexes'] = ps.policy.subject.org_units
     else:
         request['subjectOURegexes'] = [re_allow_all]
 
     if ps.policy and ps.policy.subject and len(ps.policy.subject.localities) > 0:
-        request['subjectLRegexes'] = ps.policy.subject.localities
+        if len(ps.policy.subject.localities) == 1 and ps.policy.subject.localities[0] == "":
+            request['subjectLRegexes'] = None
+        else:
+            request['subjectLRegexes'] = ps.policy.subject.localities
     else:
         request['subjectLRegexes'] = [re_allow_all]
 
     if ps.policy and ps.policy.subject and len(ps.policy.subject.states) > 0:
-        request['subjectSTRegexes'] = ps.policy.subject.states
+        if len(ps.policy.subject.states) and ps.policy.subject.states[0] == "":
+            request['subjectSTRegexes'] = None
+        else:
+            request['subjectSTRegexes'] = ps.policy.subject.states
     else:
         request['subjectSTRegexes'] = [re_allow_all]
 
     if ps.policy and ps.policy.subject and len(ps.policy.subject.countries) > 0:
-        request['subjectCValues'] = ps.policy.subject.countries
+        if len(ps.policy.subject.countries) == 1 and ps.policy.subject.countries[0] == "":
+            request['subjectCValues'] = None
+        else:
+            request['subjectCValues'] = ps.policy.subject.countries
     else:
         request['subjectCValues'] = [re_allow_all]
 


### PR DESCRIPTION
The following fields can now be disabled when creating a Policy Specification on VaaS:
* organization
* organizational units
* localities
* states
* countries

To do so, an array with an empty string must be passedd to the attribute, e.g.:
{
    "subject": {
        "orgs": [
            ""
        ],
        "orgUnits": [
            ""
        ],
        "localities": [
            "sample_locality"
        ]
    }
}