### PR TITLE
Fix policy management for VaaS after Org Unit removed

### DIFF
--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -366,8 +366,7 @@ class CloudConnection(CommonConnection):
                               data['internalPorts'] if 'internalPorts' in data else None,
                               data['fullyQualifiedDomainNames'] if 'fullyQualifiedDomainNames' in data else None,
                               data['ipRanges'] if 'ipRanges' in data else None,
-                              data['ports'] if 'ports' in data else None,
-                              data['organizationalUnitId'] if 'organizationalUnitId' in data else None
+                              data['ports'] if 'ports' in data else None
                               )
         elif status in (HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND, HTTPStatus.PRECONDITION_FAILED):
             log_errors(data)

--- a/vcert/policy/pm_cloud.py
+++ b/vcert/policy/pm_cloud.py
@@ -821,7 +821,7 @@ def build_app_update_request(app_details, cit_map):
                    'externalIpRanges': app_details.external_ip_ranges, 'internalPorts': app_details.internal_ports,
                    'fullyQualifiedDomainNames': app_details.fully_qualified_domain_names,
                    'ipRanges': app_details.ip_ranges, 'ports': app_details.ports,
-                   'organizationalUnitId': app_details.org_unit_id, 'certificateIssuingTemplateAliasIdMap': cit_map}
+                   'certificateIssuingTemplateAliasIdMap': cit_map}
     return app_request
 
 

--- a/vcert/vaas_utils.py
+++ b/vcert/vaas_utils.py
@@ -28,7 +28,7 @@ class AppDetails:
     def __init__(self, app_id=None, cit_map=None, company_id=None, name=None, description=None,
                  owner_ids_and_types=None, fq_dns=None, internal_fq_dns=None, external_ip_ranges=None,
                  internal_ip_ranges=None, internal_ports=None, fully_qualified_domain_names=None, ip_ranges=None,
-                 ports=None, org_unit_id=None):
+                 ports=None):
         """
         :param str app_id:
         :param dict cit_map:
@@ -47,7 +47,6 @@ class AppDetails:
         self.fully_qualified_domain_names = fully_qualified_domain_names
         self.ip_ranges = ip_ranges
         self.ports = ports
-        self.org_unit_id = org_unit_id
 
 
 class OwnerIdsAndTypes:


### PR DESCRIPTION
The Org Unit construct was dropped from Venafi as a Service last week and since then the certificate policy assignment feature has not worked. This update addresses that.