### PR TITLE
fix: raise error if cert not found instead of continuing within infinite while loop

### DIFF
--- a/vcert/errors.py
+++ b/vcert/errors.py
@@ -53,3 +53,7 @@ class VenafiParsingError(VenafiError):
 
 class RetrieveCertificateTimeoutError(VenafiError):
     pass
+
+
+class RetrieveCertificateNotFoundError(VenafiError):
+    pass


### PR DESCRIPTION
Working with TPP, trying to retrieve a non-existing cert would result in an infinite while loop with the following error message...
```
ERROR:root:Unknown error format: {'Error': 'Certificate test does not exist.'}
ERROR:root:Unknown error format: {'Error': 'Certificate test does not exist.'}
ERROR:root:Unknown error format: {'Error': 'Certificate test does not exist.'}
```

Instead we now log the error once and raise a `RetrieveCertificateNotFound ` error.