### PR TITLE
security: CWE-295: TLS verification disabled — VC-53768

### DIFF
--- a/examples/get_cert.py
+++ b/examples/get_cert.py
@@ -42,12 +42,13 @@ def main():
         # Connection will be chosen automatically based on which arguments are passed.
         # If token is passed CyberArk Certificate Manager, SaaS connection will be used.
         # If user, password, and URL CyberArk Certificate Manager, Self-Hosted will be used.
-        conn = Connection(url=url, token=token, user=user, password=password,
-                          http_request_kwargs={'verify': False})
         # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy, you can specify
         # a trust bundle using requests vars:
+        conn = Connection(url=url, token=token, user=user, password=password,
+                         http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        # Lab/testing only — DO NOT use in production:
         # conn = Connection(url=url, token=token, user=user, password=password,
-        #                  http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        #                   http_request_kwargs={'verify': False})
 
     request = CertificateRequest(common_name=f"{randomword(10)}.venafi.example.com")
     request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]

--- a/examples/ssh_certificates/get_cert_ssh.py
+++ b/examples/ssh_certificates/get_cert_ssh.py
@@ -31,11 +31,12 @@ def main():
     user = environ.get('TPP_USER')
     password = environ.get('TPP_PASSWORD')
 
-    connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
     # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA, or available only via proxy,
     # you can specify a trust bundle using requests vars:
-    # connector = venafi_connection(url=url, api_key=api_key, access_token=access_token,
-    #                          http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    connector = venafi_connection(url=url, user=user, password=password,
+                             http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # Lab/testing only — DO NOT use in production:
+    # connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
 
     # Create an Authentication object to request a token with the proper scope to manage SSH certificates
     auth = Authentication(user=user, password=password, scope=SCOPE_SSH)

--- a/examples/ssh_certificates/get_cert_ssh_service.py
+++ b/examples/ssh_certificates/get_cert_ssh_service.py
@@ -31,11 +31,12 @@ def main():
     user = environ.get('TPP_USER')
     password = environ.get('TPP_PASSWORD')
 
-    connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
     # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy,
     # you can specify a trust bundle using requests vars:
-    # connector = venafi_connection(url=url, api_key=api_key, access_token=access_token,
-    #                          http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    connector = venafi_connection(url=url, user=user, password=password,
+                             http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # Lab/testing only — DO NOT use in production:
+    # connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
 
     # Create an Authentication object to request a token with the proper scope to manage SSH certificates
     auth = Authentication(user=user, password=password, scope=SCOPE_SSH)

--- a/examples/tpp/get_cert_tpp_token.py
+++ b/examples/tpp/get_cert_tpp_token.py
@@ -41,11 +41,12 @@ def main():
         # If user and password are passed, you can get a new token from them.
         # If access_token and refresh_token are passed, there is no need for the username and password.
         # If only access_token is passed, the Connection will fail when token expires, as there is no way to refresh it.
-        conn = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
         # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy, you can specify
         # a trust bundle using requests vars:
-        # conn = token_connection(url=url, user=user, password=password,
-        #                         http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        conn = venafi_connection(url=url, user=user, password=password,
+                                http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        # Lab/testing only — DO NOT use in production:
+        # conn = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
 
     request = CertificateRequest(common_name=f"{random_word(10)}.venafi.example.com")
     request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]

--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -155,6 +155,9 @@ class CloudConnection(CommonConnection):
             http_request_kwargs['timeout'] = 180
         self._http_request_kwargs = http_request_kwargs
 
+        if self._http_request_kwargs.get('verify') is False:
+            log.warning("TLS certificate verification is DISABLED; credentials and private keys will be transmitted over unverified connections. This configuration is only appropriate for isolated test environments.")
+
     def __str__(self):
         return f"[Cloud] {self._base_url}"
 

--- a/vcert/connection_tpp.py
+++ b/vcert/connection_tpp.py
@@ -46,6 +46,9 @@ class TPPConnection(AbstractTPPConnection):
             http_request_kwargs['timeout'] = 180
         self._http_request_kwargs = http_request_kwargs or {}
 
+        if self._http_request_kwargs.get('verify') is False:
+            log.warning("TLS certificate verification is DISABLED; credentials and private keys will be transmitted over unverified connections. This configuration is only appropriate for isolated test environments.")
+
     def __setattr__(self, key, value):
         if key == '_base_url':
             value = self._normalize_and_verify_base_url(value)

--- a/vcert/connection_tpp_token.py
+++ b/vcert/connection_tpp_token.py
@@ -52,6 +52,9 @@ class TPPTokenConnection(AbstractTPPConnection):
             http_request_kwargs['timeout'] = 180
         self._http_request_kwargs = http_request_kwargs or {}
 
+        if self._http_request_kwargs.get('verify') is False:
+            log.warning("TLS certificate verification is DISABLED; credentials and private keys will be transmitted over unverified connections. This configuration is only appropriate for isolated test environments.")
+
     def __setattr__(self, key, value):
         if key == '_base_url':
             value = self._normalize_and_verify_base_url(value)


### PR DESCRIPTION
## Summary

Fixes CWE-295 (Improper Certificate Validation) by enabling TLS certificate verification by default in all shipped examples and adding runtime warnings when verification is explicitly disabled.

## Finding

**Severity:** High (CVSS 6.0)  
**CWE:** CWE-295 (Improper Certificate Validation) / CWE-1188 (Insecure Default)

Four shipped examples (`examples/get_cert.py`, `examples/tpp/get_cert_tpp_token.py`, `examples/ssh_certificates/get_cert_ssh.py`, `examples/ssh_certificates/get_cert_ssh_service.py`) set `http_request_kwargs={'verify': False}` as the active code path, instructing consumers to disable TLS certificate validation. The secure trust-bundle alternative was present only as a commented-out suggestion.

The SDK connection classes (`TPPConnection`, `TPPTokenConnection`, `CloudConnection`) forward `http_request_kwargs` verbatim to all `requests` calls without inspecting, warning, or rejecting `verify=False`. This includes calls that transmit Venafi credentials, session tokens, key passphrases, and private keys.

With verification disabled, an on-path attacker can present any certificate, capture transmitted secrets (username/password, bearer tokens, key passphrases), and substitute server-supplied cryptographic material.

## Remediation

**Examples (4 files):**
- Changed active code path from `verify=False` to `verify="/path-to/bundle.pem"` (trust bundle)
- Moved `verify=False` to a comment explicitly labeled "Lab/testing only — DO NOT use in production"
- Consumers copying examples verbatim now get certificate validation by default

**SDK connection classes (3 files):**
- Added warning in `TPPTokenConnection.__init__`, `TPPConnection.__init__`, and `CloudConnection.__init__`
- Warning fires when `http_request_kwargs.get('verify') is False`
- Warning message: "TLS certificate verification is DISABLED; credentials and private keys will be transmitted over unverified connections. This configuration is only appropriate for isolated test environments."
- Warning uses existing logger instances; no new imports or signature changes
- Check uses `is False` to distinguish explicit boolean from CA-bundle path string or omitted key

## Verification

- **Syntax check:** All 7 modified files compile without errors (`python3 -m py_compile`)
- **Diff scope:** 7 files changed, 25 insertions(+), 12 deletions(-)
- **No behavioral change for secure configurations:** Trust-bundle and default (no `verify` key) paths unchanged
- **Detective control:** SDK warning fires at connection instantiation when `verify=False`; does not prevent (consumers can still override), but alerts operators
- **Preventive control:** Examples now default to secure configuration; insecure path requires conscious uncomment

Addresses Jira ticket VC-53768.