### PR TITLE
security: CWE-502: unsafe YAML deserialization — VC-53769

### DIFF
--- a/vcert/parser/yaml_parser.py
+++ b/vcert/parser/yaml_parser.py
@@ -46,7 +46,7 @@ def parse(yaml_string):
         log.error('yaml string is empty')
         raise VenafiParsingError
 
-    yaml = YAML(typ='unsafe')
+    yaml = YAML(typ='safe')
     data = yaml.load(yaml_string)
     policy = parse_data(data)
 
@@ -65,6 +65,6 @@ def serialize(policy_spec, file_path):
     abs_path = os.path.abspath(file_path)
     data = parse_policy_spec(policy_spec)
     f = open(abs_path, 'w')
-    yaml = YAML(typ='unsafe')
+    yaml = YAML(typ='safe')
     yaml.dump(data, f)
     f.close()


### PR DESCRIPTION
## Summary

This PR fixes CWE-502 (Deserialization of Untrusted Data) by replacing `YAML(typ='unsafe')` with `YAML(typ='safe')` in the YAML parser.

## Finding

The `vcert.parser.yaml_parser` module used ruamel.yaml's unsafe loader mode, which honors Python object constructor tags like `!!python/object/apply`. This allowed arbitrary code execution when processing untrusted YAML files. An attacker who could control a policy YAML file fed to `parse_file()` or `parse()` could execute arbitrary Python code in the context of the process holding Venafi credentials.

**CVSS 7.3** (CVSS:4.0/AV:L/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N)

## Remediation

Changed two instances in `vcert/parser/yaml_parser.py`:
- Line 49: `YAML(typ='unsafe')` → `YAML(typ='safe')` (parse path)
- Line 68: `YAML(typ='unsafe')` → `YAML(typ='safe')` (serialize path)

The safe loader only accepts standard YAML types (scalars, sequences, mappings) and rejects all `!!python/*` constructor tags. This is functionally equivalent for legitimate policy specs, which `parse_data()` expects as plain dicts/lists/scalars.

## Verification

The remediation is minimal and surgical:
- Only changed the loader type parameter from `'unsafe'` to `'safe'`
- No new imports, no signature changes, no functional changes to policy parsing
- ruamel.yaml's safe loader will raise `ConstructorError` on any `!!python/*` tags, blocking exploitation before code execution

The fix prevents the PoC payload `!!python/object/apply:os.system ["touch /tmp/pwned"]` from executing, as the safe loader has no registered constructor for Python object tags.