### PR TITLE
security: CWE-532: Redact sensitive data from debug logs — VC-53770

### DIFF
--- a/vcert/common.py
+++ b/vcert/common.py
@@ -755,7 +755,7 @@ class CommonConnection:
             log.debug(r.content.decode())
             return r.status_code, r.content.decode()
         elif content_type.startswith(MIME_OCTET_STREAM):
-            log.debug(r.content)
+            log.debug(f"Received {len(r.content)} bytes (octet-stream body not logged)")
             return r.status_code, r.content
         else:
             log.error(f"Unexpected content type: {content_type} for request {r.request.url}")

--- a/vcert/connection_tpp.py
+++ b/vcert/connection_tpp.py
@@ -90,7 +90,7 @@ class TPPConnection(AbstractTPPConnection):
     def _get(self, url="", params=None):
         if not self._token or self._token[1] < time.time() + 1:
             self.auth()
-            log.debug(f"Token is {self._token[0]}, timeout is {self._token[1]}")
+            log.debug(f"Token is [REDACTED], timeout is {self._token[1]}")
 
         r = requests.get(f"{self._base_url}{url}",
                          headers={TOKEN_HEADER_NAME: self._token[0],
@@ -103,7 +103,7 @@ class TPPConnection(AbstractTPPConnection):
     def _post(self, url, data=None):
         if not self._token or self._token[1] < time.time() + 1:
             self.auth()
-            log.debug(f"Token is {self._token[0]}, timeout is {self._token[1]}")
+            log.debug(f"Token is [REDACTED], timeout is {self._token[1]}")
 
         if isinstance(data, dict):
             r = requests.post(f"{self._base_url}{url}",
@@ -120,7 +120,7 @@ class TPPConnection(AbstractTPPConnection):
     def _put(self, url, data=None):
         if not self._token or self._token[1] < time.time() + 1:
             self.auth()
-            log.debug(f"Token is {self._token[0]}, timeout is {self._token[1]}")
+            log.debug(f"Token is [REDACTED], timeout is {self._token[1]}")
 
         if isinstance(data, dict):
             r = requests.put(f"{self._base_url}{url}",

--- a/vcert/connection_tpp_token.py
+++ b/vcert/connection_tpp_token.py
@@ -126,7 +126,9 @@ class TPPTokenConnection(AbstractTPPConnection):
             headers[HEADER_AUTHORIZATION] = token
 
         if isinstance(data, dict):
-            log.debug(f"POST Request\n\tURL: {self._base_url+url}\n\tHeaders:{headers}\n\tBody:{data}\n")
+            safe_headers = {k: ('***' if k == HEADER_AUTHORIZATION else v) for k, v in headers.items()}
+            safe_data = {k: ('***' if k in ('password', 'Password', 'refresh_token', 'client_secret', 'PrivateKeyPassphrase') else v) for k, v in data.items()}
+            log.debug(f"POST Request\n\tURL: {self._base_url+url}\n\tHeaders:{safe_headers}\n\tBody:{safe_data}\n")
             r = requests.post(self._base_url + url, headers=headers, json=data,  **self._http_request_kwargs)  # nosec B113
         else:
             log.error(f"Unexpected client data type: {type(data)} for {url}")
@@ -146,7 +148,9 @@ class TPPTokenConnection(AbstractTPPConnection):
             headers[HEADER_AUTHORIZATION] = token
 
         if isinstance(data, dict):
-            log.debug(f"POST Request\n\tURL: {self._base_url + url}\n\tHeaders:{headers}\n\tBody:{data}\n")
+            safe_headers = {k: ('***' if k == HEADER_AUTHORIZATION else v) for k, v in headers.items()}
+            safe_data = {k: ('***' if k in ('password', 'Password', 'refresh_token', 'client_secret', 'PrivateKeyPassphrase') else v) for k, v in data.items()}
+            log.debug(f"POST Request\n\tURL: {self._base_url + url}\n\tHeaders:{safe_headers}\n\tBody:{safe_data}\n")
             r = requests.put(self._base_url + url, headers=headers, json=data,
                               **self._http_request_kwargs)  # nosec B113
         else:
@@ -157,13 +161,13 @@ class TPPTokenConnection(AbstractTPPConnection):
     def _check_token(self):
         if not self._auth.access_token:
             self.get_access_token()
-            log.debug(f"Token is {self._auth.access_token}, expire date is {self._auth.token_expires}")
+            log.debug(f"Token is [REDACTED], expire date is {self._auth.token_expires}")
 
         # Token expired, get new token
         elif self._auth.token_expires and self._auth.token_expires < time.time():
             if self._auth.refresh_token:
                 self.refresh_access_token()
-                log.debug(f"Token is {self._auth.access_token}, expire date is {self._auth.token_expires}")
+                log.debug(f"Token is [REDACTED], expire date is {self._auth.token_expires}")
             else:
                 raise AuthenticationError("Access Token expired. No refresh token provided.")
 


### PR DESCRIPTION
## Summary

Fixed CWE-532 (Insertion of Sensitive Information into Log File) by redacting passwords, tokens, API keys, and private key material from debug log output.

## Finding

**CWE-532**: Secrets in debug log (CVSS: 5.6)

When debug logging is enabled, the SDK was logging plaintext credentials and sensitive data:
- TPP usernames and passwords during authentication
- OAuth bearer tokens and refresh tokens
- API keys (x-venafi-api-key)
- Private key passphrases
- Raw private key material (octet-stream responses)

These secrets were logged at multiple points:
- `TPPTokenConnection._post()/_put()` logged full request headers (containing `Authorization: Bearer <token>`) and bodies (containing passwords/passphrases)
- `TPPTokenConnection._check_token()` logged raw access tokens
- `TPPConnection._get()/_post()/_put()` logged raw API keys
- `CommonConnection.process_server_response()` logged raw octet-stream responses containing private keys

Anyone with read access to application logs could recover working Venafi credentials.

## Remediation

Applied minimal focused changes to redact sensitive data from log output:

1. **vcert/connection_tpp_token.py** (lines 129, 149): Create redacted copies of headers and data dictionaries before logging
   - Mask `Authorization` header value
   - Mask sensitive data keys: `password`, `Password`, `refresh_token`, `client_secret`, `PrivateKeyPassphrase`

2. **vcert/connection_tpp_token.py** (lines 160, 166): Replace raw token values with `[REDACTED]` placeholder

3. **vcert/connection_tpp.py** (lines 93, 106, 123): Replace raw API key values with `[REDACTED]` placeholder

4. **vcert/common.py** (line 758): Log byte count instead of raw octet-stream content

All changes preserve the original unredacted values in the actual network requests - only the log output is modified.

## Verification

**Files changed**: 3 files, 12 insertions(+), 8 deletions(-)
- `vcert/common.py`
- `vcert/connection_tpp.py`
- `vcert/connection_tpp_token.py`

**Impact**: No functional changes to SDK behavior. Network requests remain identical. Only debug log output is modified to protect sensitive data.

**Testing note**: Test suite has pre-existing dependency issues unrelated to these changes (missing `six` module). The remediation only modifies logging statements and does not affect imports, logic, or network behavior.

---
🤖 Generated with Project Logos Pattern-C security fixer