### PR TITLE
security: CWE-295: warn on TLS verify=False, fix insecure examples — VC-53768

### DIFF
--- a/examples/get_cert.py
+++ b/examples/get_cert.py
@@ -42,12 +42,13 @@ def main():
         # Connection will be chosen automatically based on which arguments are passed.
         # If token is passed CyberArk Certificate Manager, SaaS connection will be used.
         # If user, password, and URL CyberArk Certificate Manager, Self-Hosted will be used.
+        # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA,
+        # or available only via proxy, specify the CA trust bundle path:
         conn = Connection(url=url, token=token, user=user, password=password,
-                          http_request_kwargs={'verify': False})
-        # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy, you can specify
-        # a trust bundle using requests vars:
+                          http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        # Lab/testing only — DO NOT use in production:
         # conn = Connection(url=url, token=token, user=user, password=password,
-        #                  http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        #                  http_request_kwargs={'verify': False})
 
     request = CertificateRequest(common_name=f"{randomword(10)}.venafi.example.com")
     request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]

--- a/examples/ssh_certificates/get_cert_ssh.py
+++ b/examples/ssh_certificates/get_cert_ssh.py
@@ -31,11 +31,13 @@ def main():
     user = environ.get('TPP_USER')
     password = environ.get('TPP_PASSWORD')
 
-    connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
-    # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA, or available only via proxy,
-    # you can specify a trust bundle using requests vars:
-    # connector = venafi_connection(url=url, api_key=api_key, access_token=access_token,
-    #                          http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA,
+    # or available only via proxy, specify the CA trust bundle path:
+    connector = venafi_connection(url=url, user=user, password=password,
+                                  http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # Lab/testing only — DO NOT use in production:
+    # connector = venafi_connection(url=url, user=user, password=password,
+    #                               http_request_kwargs={'verify': False})
 
     # Create an Authentication object to request a token with the proper scope to manage SSH certificates
     auth = Authentication(user=user, password=password, scope=SCOPE_SSH)

--- a/examples/ssh_certificates/get_cert_ssh_service.py
+++ b/examples/ssh_certificates/get_cert_ssh_service.py
@@ -31,11 +31,13 @@ def main():
     user = environ.get('TPP_USER')
     password = environ.get('TPP_PASSWORD')
 
-    connector = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
-    # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy,
-    # you can specify a trust bundle using requests vars:
-    # connector = venafi_connection(url=url, api_key=api_key, access_token=access_token,
-    #                          http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA,
+    # or available only via proxy, specify the CA trust bundle path:
+    connector = venafi_connection(url=url, user=user, password=password,
+                                  http_request_kwargs={"verify": "/path-to/bundle.pem"})
+    # Lab/testing only — DO NOT use in production:
+    # connector = venafi_connection(url=url, user=user, password=password,
+    #                               http_request_kwargs={'verify': False})
 
     # Create an Authentication object to request a token with the proper scope to manage SSH certificates
     auth = Authentication(user=user, password=password, scope=SCOPE_SSH)

--- a/examples/tpp/get_cert_tpp_token.py
+++ b/examples/tpp/get_cert_tpp_token.py
@@ -41,11 +41,13 @@ def main():
         # If user and password are passed, you can get a new token from them.
         # If access_token and refresh_token are passed, there is no need for the username and password.
         # If only access_token is passed, the Connection will fail when token expires, as there is no way to refresh it.
-        conn = venafi_connection(url=url, user=user, password=password, http_request_kwargs={'verify': False})
-        # If your CyberArk Certificate Manager, Self-Hosted server certificate signed with your own CA, or available only via proxy, you can specify
-        # a trust bundle using requests vars:
-        # conn = token_connection(url=url, user=user, password=password,
-        #                         http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        # If your CyberArk Certificate Manager, Self-Hosted server certificate is signed with your own CA,
+        # or available only via proxy, specify the CA trust bundle path:
+        conn = venafi_connection(url=url, user=user, password=password,
+                                 http_request_kwargs={"verify": "/path-to/bundle.pem"})
+        # Lab/testing only — DO NOT use in production:
+        # conn = venafi_connection(url=url, user=user, password=password,
+        #                          http_request_kwargs={'verify': False})
 
     request = CertificateRequest(common_name=f"{random_word(10)}.venafi.example.com")
     request.san_dns = ["www.client.venafi.example.com", "ww1.client.venafi.example.com"]

--- a/vcert/connection_cloud.py
+++ b/vcert/connection_cloud.py
@@ -153,6 +153,12 @@ class CloudConnection(CommonConnection):
             http_request_kwargs = {'timeout': 180}
         elif 'timeout' not in http_request_kwargs:
             http_request_kwargs['timeout'] = 180
+        if http_request_kwargs.get('verify') is False:
+            log.warning(
+                "TLS certificate verification is DISABLED (verify=False). "
+                "This allows interception of credentials and private-key material. "
+                "Use a CA trust-bundle path (verify='/path/to/bundle.pem') in production."
+            )
         self._http_request_kwargs = http_request_kwargs
 
     def __str__(self):

--- a/vcert/connection_tpp.py
+++ b/vcert/connection_tpp.py
@@ -44,6 +44,12 @@ class TPPConnection(AbstractTPPConnection):
             http_request_kwargs = {'timeout': 180}
         elif 'timeout' not in http_request_kwargs:
             http_request_kwargs['timeout'] = 180
+        if http_request_kwargs.get('verify') is False:
+            log.warning(
+                "TLS certificate verification is DISABLED (verify=False). "
+                "This allows interception of credentials and private-key material. "
+                "Use a CA trust-bundle path (verify='/path/to/bundle.pem') in production."
+            )
         self._http_request_kwargs = http_request_kwargs or {}
 
     def __setattr__(self, key, value):

--- a/vcert/connection_tpp_token.py
+++ b/vcert/connection_tpp_token.py
@@ -50,6 +50,12 @@ class TPPTokenConnection(AbstractTPPConnection):
             http_request_kwargs = {'timeout': 180}
         elif 'timeout' not in http_request_kwargs:
             http_request_kwargs['timeout'] = 180
+        if http_request_kwargs.get('verify') is False:
+            log.warning(
+                "TLS certificate verification is DISABLED (verify=False). "
+                "This allows interception of credentials and private-key material. "
+                "Use a CA trust-bundle path (verify='/path/to/bundle.pem') in production."
+            )
         self._http_request_kwargs = http_request_kwargs or {}
 
     def __setattr__(self, key, value):


### PR DESCRIPTION
## Summary
- Add runtime `log.warning` in `TPPConnection`, `TPPTokenConnection`, and `CloudConnection` constructors when `http_request_kwargs['verify'] is False`
- Flip four shipped examples so the CA-bundle path (`verify="/path-to/bundle.pem"`) is the active line and `verify=False` is relegated to a clearly-labelled lab-only comment

## Finding
**CWE-295** (Improper Certificate Validation) / **CWE-1188** (Insecure Default)

All three connection classes (`connection_tpp.py`, `connection_tpp_token.py`, `connection_cloud.py`) splatted `**self._http_request_kwargs` into every `requests` call with no guard on the `verify` key. Four shipped examples (`examples/get_cert.py`, `examples/tpp/get_cert_tpp_token.py`, `examples/ssh_certificates/get_cert_ssh.py`, `examples/ssh_certificates/get_cert_ssh_service.py`) set `verify=False` as the active code path, so consumers copying them verbatim sent Venafi credentials, session tokens, and private-key material over TLS sessions with no server-certificate validation.

## Remediation
- **SDK guard (detective):** After the timeout normalisation block in each constructor, check `http_request_kwargs.get('verify') is False` and emit a `WARNING`-level log message. Uses `is False` so CA-bundle strings and the absent-key default (`None`) are not flagged.
- **Example flip:** The trust-bundle variant is now the live line; `verify=False` is moved to a `# Lab/testing only — DO NOT use in production` comment.

## Verification
- 7 files changed: 3 SDK sources + 4 examples
- `python -m py_compile` passes on all modified files
- Warning guard: `http_request_kwargs.get('verify') is False` is branch-free and evaluated immediately after the dict is guaranteed non-`None`
- No new imports, no API signature changes
- Pre-existing test failures (`ModuleNotFoundError: No module named 'six'`) are an unrelated environment issue unaffected by this change