### PR TITLE
test(tpp): skip legacy API key auth tests on TPP 22.2+ [VC-55790]

### DIFF
--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -82,6 +82,7 @@ class TestTPPTokenSSHCertificate(unittest.TestCase):
         log.debug(f"{TPP_SSH_CADN} default principals: {ssh_config.ca_principals}")
 
 
+@unittest.skip("TPPConnection uses API key auth (/vedsdk/authorize/) which is not supported on TPP 22.2+. Use TPPTokenConnection instead.")
 class TestTPPSSHCertificate(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         self.tpp_conn = TPPConnection(TPP_USER, TPP_PASSWORD, TPP_URL, http_request_kwargs={'verify': "/tmp/chain.pem"})

--- a/tests/test_tpp.py
+++ b/tests/test_tpp.py
@@ -41,6 +41,7 @@ class TestFakeMethods(unittest.TestCase):
         enroll(conn, zone, cn)
 
 
+@unittest.skip("TPPConnection uses API key auth (/vedsdk/authorize/) which is not supported on TPP 22.2+. Use TPPTokenConnection instead.")
 class TestTPPMethods(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         self.tpp_zone = TPP_ZONE

--- a/tests/test_tpp_token.py
+++ b/tests/test_tpp_token.py
@@ -74,14 +74,14 @@ class TestTPPTokenMethods(unittest.TestCase):
             cert_config = self.tpp_conn._get_certificate_details(cert_guid)
             self.assertEqual(cert_config['Origin'], "Venafi VCert-Python")
         except Exception as err:
-            self.fail(f"Error in test: {err.__str__}")
+            self.fail(f"Error in test: {str(err)}")
 
     def test_tpp_token_enroll_origin(self):
         cn = f"{random_word(10)}.venafi.example.com"
         try:
             cert_id, pkey, cert, _, _ = enroll(self.tpp_conn, self.tpp_zone, cn)
         except Exception as err:
-            self.fail(f"Error in test: {err.__str__()}")
+            self.fail(f"Error in test: {str(err)}")
 
     def test_tpp_token_renew(self):
         cn = f"{random_word(10)}.venafi.example.com"
@@ -242,7 +242,7 @@ class TestTPPTokenMethods(unittest.TestCase):
         except ClientBadData:
             self.fail("Error in Test Data")
         except ServerUnexptedBehavior as sub:
-            self.fail(f"Error from server: {sub.__str__()}")
+            self.fail(f"Error from server: {str(sub)}")
 
     def test_refresh_access_token(self):
         try:
@@ -255,7 +255,7 @@ class TestTPPTokenMethods(unittest.TestCase):
         except ClientBadData:
             self.fail("Error in Test Data")
         except ServerUnexptedBehavior as sub:
-            self.fail(f"Error from server: {sub.__str__()}")
+            self.fail(f"Error from server: {str(sub)}")
 
     def test_revoke_access_token(self):
         try:
@@ -263,7 +263,7 @@ class TestTPPTokenMethods(unittest.TestCase):
             status, resp = self.tpp_conn.revoke_access_token()
             self.assertEqual(status, 200)
         except Exception as err:
-            self.fail(f"Error happened: {err.__str__()}")
+            self.fail(f"Error happened: {str(err)}")
 
         cn = f"{random_word(10)}.venafi.example.com"
         with self.assertRaises(Exception):


### PR DESCRIPTION
## Summary
`TPPConnection` authenticates via `POST /vedsdk/authorize/`, which was deprecated in TPP 22.2 and is no longer available on TPP 26.1+. On newer instances, all tests in `TestTPPMethods` and `TestTPPSSHCertificate` fail at the authentication step. This PR skips both classes as an interim measure.

Also fixes incorrect `err.__str__()` and `err.__str__` calls in `test_tpp_token.py`, replacing them with the idiomatic `str(err)`.