### PR TITLE
test(vaas): skip revoke-by-thumbprint test on BUILTIN_CA zone [VC-55862]

### DIFF
--- a/tests/test_vaas.py
+++ b/tests/test_vaas.py
@@ -214,6 +214,7 @@ class TestVaaSMethods(unittest.TestCase):
         except Exception as e:
             log.error(msg=f"Error retiring certificate by thumbprint: {str(e)}")
 
+    @unittest.skip("Zone is backed by a BUILTIN_CA, which does not support revocation")
     def test_cloud_revoke_by_thumbprint(self):
         # Cryptographic revocation via the GraphQL CA-operations mutation (thumbprint-keyed).
         # revoke_cert uppercases the thumbprint internally, so a lowercase hexlify is fine here.


### PR DESCRIPTION
## Summary
- `test_cloud_revoke_by_thumbprint` fails on every run because the zone it uses is backed by a BUILTIN_CA, which does not support certificate revocation
- Skips the test to unblock the pipeline while the underlying zone/test setup is fixed

## Test
- [x]  Jenkins pipeline passed on [vc-55862/skip-vaas-revoke-builtin-ca](https://github.com/Venafi/vcert-python/tree/vc-55862/skip-vaas-revoke-builtin-ca) branch